### PR TITLE
debug: add ability to specify log levels with log()

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -234,7 +234,7 @@ class App extends React.Component {
         return wrapper
       })
       .catch(err => {
-        log(`Wrapper init, fatal error: ${err.name}. ${err.message}.`)
+        log('error')(`Wrapper init, fatal error: ${err.name}. ${err.message}.`)
         this.setState({
           appsStatus: APPS_STATUS_ERROR,
           daoStatus: DAO_STATUS_ERROR,

--- a/src/utils.js
+++ b/src/utils.js
@@ -108,9 +108,19 @@ export function appendTrailingSlash(str) {
   return str + (str.endsWith('/') ? '' : '/')
 }
 
-export function log(...params) {
+const LOG_LEVELS = ['debug', 'info', 'log', 'warn', 'error']
+export function log(levelOrMessage, ...params) {
+  const level = LOG_LEVELS.includes(levelOrMessage) ? levelOrMessage : null
+  if (level && !params.length) {
+    return (...params) => log(level, ...params)
+  }
+
   if (process.env.NODE_ENV !== 'production') {
-    console.log(...params)
+    if (level) {
+      console[level](...params)
+    } else {
+      console.log(levelOrMessage, ...params)
+    }
   }
 }
 
@@ -121,6 +131,7 @@ export function isString(str) {
 export function isHumanReadable(str = '') {
   return !str.split(' ').some(word => word.length > 26)
 }
+
 // Thanks to https://stackoverflow.com/a/12646864
 export function shuffleArray(original) {
   const array = [...original]


### PR DESCRIPTION
Bit of an experiment to see how we could add debug levels to our `log()` utility.

Took a quick look around npm and I swear something similar to this must exist, but I couldn't find it 🤷‍♂️. Any suggestions (more battle tested than this one) welcome!

---------

Couldn't come up with an API that felt nice without the transparent binding, so this is inspired somewhat by the [`debug`](https://www.npmjs.com/package/debug) API:

```js
log('some message')
log('warn')('a warning')
log('error', 'a bad warning')
```