### PR TITLE
DAO-104 CI job error

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         node-version: 14
     - name: Install dependencies
-      run: yarn install --frozen-lockfile
+      run: yarn install --frozen-lockfile --network-concurrency 1
     - name: Build Aragon
       run: yarn build
     - name: Run BundleWatch

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
       with:
         node-version: 14
     - name: Install dependencies
+      # TODO remove --network-concurrency 1 once use-wallet 0.9.0 is published
       run: yarn install --frozen-lockfile --network-concurrency 1
     - name: Build Aragon
       run: yarn build


### PR DESCRIPTION
This is a temporary workaround to make the CI test to pass. The proper fix is to use the use-wallet npm package instead of github url.  Once use-wallet 0.9.0 is published, remove `--network-concurrency 1`