### PR TITLE
DAO-74: client crash connecting wallet

### DIFF
--- a/src/onboarding/Welcome/OpenOrg.js
+++ b/src/onboarding/Welcome/OpenOrg.js
@@ -39,7 +39,8 @@ function OpenOrg({ onOpenOrg, onBack }) {
   // focus on mount
   const handleDomainFieldRef = useCallback(ref => {
     if (ref) {
-      ref.focus()
+      // TODO: workaround
+      // ref.focus()
     }
   }, [])
 

--- a/src/onboarding/Welcome/OpenOrg.js
+++ b/src/onboarding/Welcome/OpenOrg.js
@@ -39,7 +39,7 @@ function OpenOrg({ onOpenOrg, onBack }) {
   // focus on mount
   const handleDomainFieldRef = useCallback(ref => {
     if (ref) {
-      // TODO: workaround
+      // TODO: workaround see https://github.com/aragon/client/pull/1571
       // ref.focus()
     }
   }, [])


### PR DESCRIPTION
The fix is just a workaround and there's a trade off, the workaround disables the focus on the domain field.

Potential fix:
1) Upgrade react-spring to v9.  Client is currently on ^7.2.10.
See this issue from react-spring: https://github.com/pmndrs/react-spring/issues/576
* I tried upgrading but hit a lot of errors about `cannot render functions...`

2) Upgrade use-wallet
* in the react-spring issue, there's a mention that the latest version of use-wallet fixes this issue. I tried v0.9.0, that didn't work. but, surprisingly, the multibranch Client does not have this issue.

3) Fix issue in aragon/ui
I found the workaround while testing with `<Transaction> keys` workaround mentioned in the react-spring issue.  After I converted this https://github.com/aragon/client/blob/master/src/components/AccountModule/AccountModulePopover.js#L106 to a string (currently, it's a function), the client no longer crashes but the account dialog closes after selecting a wallet. I noticed the focus moved back to the input field and I suspect it's related to the UI issue: https://github.com/aragon/ui/issues/813


 