### PR TITLE
Security fix for ReDoS

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -134,9 +134,10 @@ export function shuffleArray(original) {
   return array
 }
 
+// https://www.regular-expressions.info/email.html
 export function validateEmail(email) {
   // eslint-disable-next-line no-useless-escape
-  return /^.+\@.+\..+$/.test(email)
+  return /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/.test(email)
 }
 
 export const iOS =

--- a/src/utils.js
+++ b/src/utils.js
@@ -138,7 +138,6 @@ export function getLocalStorageKey(key, networkType) {
   return `${networkType}:${key}`
 }
 
-// https://www.regular-expressions.info/email.html
 export function validateEmail(email) {
   // eslint-disable-next-line no-useless-escape
   return /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/.test(email)

--- a/src/utils.js
+++ b/src/utils.js
@@ -134,6 +134,10 @@ export function shuffleArray(original) {
   return array
 }
 
+export function getLocalStorageKey(key, networkType) {
+  return `${networkType}:${key}`
+}
+
 // https://www.regular-expressions.info/email.html
 export function validateEmail(email) {
   // eslint-disable-next-line no-useless-escape


### PR DESCRIPTION
`validateEmail` functionality using vulnerable regex to verify email. Fixing the issue by Switch email pattern to the practical implementation of RFC 5322

Reported in https://www.huntr.dev/bounties/7b782f86-1e6c-4160-ac0e-f708a7ec974b/