### PR TITLE
DAO-308: Set Polygon DAI address

### DIFF
--- a/src/network-config.js
+++ b/src/network-config.js
@@ -106,7 +106,7 @@ export const networkConfigs = {
       ensRegistry:
         localEnsRegistryAddress || '0x3c70a0190d09f34519e6e218364451add21b7d4b',
       governExecutorProxy: null,
-      dai: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
+      dai: '0x8f3Cf7ad23Cd3CaDbD9735AFf958023239c6A063',
     },
     nodes: {
       defaultEth:

--- a/src/network-config.js
+++ b/src/network-config.js
@@ -106,6 +106,7 @@ export const networkConfigs = {
       ensRegistry:
         localEnsRegistryAddress || '0x3c70a0190d09f34519e6e218364451add21b7d4b',
       governExecutorProxy: null,
+      dai: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
     },
     nodes: {
       defaultEth:
@@ -124,6 +125,7 @@ export const networkConfigs = {
       ensRegistry:
         localEnsRegistryAddress || '0x431f0eed904590b176f9ff8c36a1c4ff0ee9b982',
       governExecutorProxy: null,
+      dai: '0x94f417C155bB3fF7365828Bb7aCD26E84C17e830',
     },
     nodes: {
       defaultEth: 'wss://matic-testnet-archive-ws.bwarelabs.com',

--- a/src/templates/dandelion/components/TokenSelector/TokenSelectorInstance.js
+++ b/src/templates/dandelion/components/TokenSelector/TokenSelectorInstance.js
@@ -13,7 +13,8 @@ const TokenSelectorInstance = React.memo(function TokenSelectorInstance({
 }) {
   const hasDescription = useMemo(() => {
     return name || !addressesEqual(address, TOKEN_FAKE_ADDRESS)
-  })
+  }, [name, address])
+
   return (
     <div
       css={`

--- a/src/templates/dandelion/components/TokenSelector/TokenSelectorInstance.js
+++ b/src/templates/dandelion/components/TokenSelector/TokenSelectorInstance.js
@@ -1,8 +1,8 @@
-import React from 'react'
+import React, { useMemo } from 'react'
 import styled from 'styled-components'
 import { addressesEqual, GU, tokenIconUrl } from '@aragon/ui'
 import { shortenAddress } from '../../../../util/web3'
-import { ETHER_TOKEN_FAKE_ADDRESS } from '../../config/helpers/tokens'
+import { TOKEN_FAKE_ADDRESS } from '../../config/helpers/tokens'
 
 /* eslint-disable react/prop-types */
 const TokenSelectorInstance = React.memo(function TokenSelectorInstance({
@@ -11,6 +11,9 @@ const TokenSelectorInstance = React.memo(function TokenSelectorInstance({
   symbol,
   showIcon = true,
 }) {
+  const hasDescription = useMemo(() => {
+    return name || !addressesEqual(address, TOKEN_FAKE_ADDRESS)
+  })
   return (
     <div
       css={`
@@ -38,7 +41,7 @@ const TokenSelectorInstance = React.memo(function TokenSelectorInstance({
         </span>
       )}
       <div>
-        (
+        {hasDescription && <>(</>}
         {name && (
           <span
             css={`
@@ -50,7 +53,7 @@ const TokenSelectorInstance = React.memo(function TokenSelectorInstance({
             {name}
           </span>
         )}
-        {!addressesEqual(address, ETHER_TOKEN_FAKE_ADDRESS) && (
+        {!addressesEqual(address, TOKEN_FAKE_ADDRESS) && (
           <span
             css={`
               margin-left: ${1 * GU}px;
@@ -59,7 +62,7 @@ const TokenSelectorInstance = React.memo(function TokenSelectorInstance({
             {shortenAddress(address)}
           </span>
         )}
-        )
+        {hasDescription && <>)</>}
       </div>
     </div>
   )

--- a/src/templates/dandelion/config/helpers/getBlockTime.js
+++ b/src/templates/dandelion/config/helpers/getBlockTime.js
@@ -6,6 +6,8 @@ const NETWORK_TIMES = new Map([
   ['ropsten', 11],
   ['goerli', 15],
   ['private', 2],
+  ['matic', 2],
+  ['mumbai', 2],
 ])
 export default function getBlockTime(networkType) {
   return NETWORK_TIMES.get(networkType) || null

--- a/src/templates/dandelion/config/helpers/tokens.js
+++ b/src/templates/dandelion/config/helpers/tokens.js
@@ -1,7 +1,7 @@
-import { getDaiTokenAddress } from '../../../../network-config'
+import { KNOWN_CHAINS } from '../../../../contexts/wallet'
+import { getDaiTokenAddress, getChainId } from '../../../../network-config'
 
-export const ETHER_TOKEN_FAKE_ADDRESS =
-  '0x0000000000000000000000000000000000000000'
+export const TOKEN_FAKE_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 const getDaiToken = networkType => ({
   symbol: 'DAI',
@@ -9,18 +9,21 @@ const getDaiToken = networkType => ({
   address: getDaiTokenAddress(networkType),
 })
 
-const ETHER_TOKEN = {
-  symbol: 'ETH',
-  name: 'Ether',
-  address: ETHER_TOKEN_FAKE_ADDRESS,
+const getNativeCurrency = networkType => {
+  const chainId = getChainId(networkType)
+  const symbol = KNOWN_CHAINS.get(chainId)?.nativeCurrency.symbol
+  return {
+    symbol,
+    address: TOKEN_FAKE_ADDRESS,
+  }
 }
 
 export function getDefaultRedeemableTokens(networkType) {
-  return [ETHER_TOKEN, getDaiToken(networkType)]
+  return [getNativeCurrency(networkType), getDaiToken(networkType)]
 }
 
 export function getDefaultAcceptedTokens(networkType) {
-  return [ETHER_TOKEN, getDaiToken(networkType)]
+  return [getNativeCurrency(networkType), getDaiToken(networkType)]
 }
 
 export function getDefaultLockTokenByNetwork(networkType) {

--- a/src/templates/dandelion/config/screens/RedemptionsScreen.js
+++ b/src/templates/dandelion/config/screens/RedemptionsScreen.js
@@ -10,7 +10,7 @@ import {
 import MultiTokenSelector from '../../components/TokenSelector/MultiTokenSelector'
 import {
   getDefaultRedeemableTokens,
-  ETHER_TOKEN_FAKE_ADDRESS,
+  TOKEN_FAKE_ADDRESS,
 } from '../helpers/tokens'
 import { shortenAddress } from '../../../../util/web3'
 import { useWallet } from '../../../../contexts/wallet'
@@ -231,7 +231,7 @@ function formatReviewFields(screenData) {
             `}
           >
             <span>{token.symbol || 'Custom token'}</span>
-            {!addressesEqual(token.address, ETHER_TOKEN_FAKE_ADDRESS) && (
+            {!addressesEqual(token.address, TOKEN_FAKE_ADDRESS) && (
               <span> {shortenAddress(token.address)}</span>
             )}
           </div>

--- a/src/templates/dandelion/config/screens/TokenRequestScreen.js
+++ b/src/templates/dandelion/config/screens/TokenRequestScreen.js
@@ -8,10 +8,7 @@ import {
   KnownAppBadge,
 } from '../../../kit'
 import MultiTokenSelector from '../../components/TokenSelector/MultiTokenSelector'
-import {
-  getDefaultAcceptedTokens,
-  ETHER_TOKEN_FAKE_ADDRESS,
-} from '../helpers/tokens'
+import { getDefaultAcceptedTokens, TOKEN_FAKE_ADDRESS } from '../helpers/tokens'
 import { shortenAddress } from '../../../../util/web3'
 import { useWallet } from '../../../../contexts/wallet'
 
@@ -230,7 +227,7 @@ function formatReviewFields(screenData) {
             `}
           >
             <span>{token.symbol || 'Custom token'}</span>
-            {!addressesEqual(token.address, ETHER_TOKEN_FAKE_ADDRESS) && (
+            {!addressesEqual(token.address, TOKEN_FAKE_ADDRESS) && (
               <span> {shortenAddress(token.address)}</span>
             )}
           </div>


### PR DESCRIPTION
This fix is needed for DAO creation to work for Dandelion template... Without this fix, we can move to next screen.

Other issues to be fixed later:
1) ETH/MATIC descriptive name no longer displays on the DAO creation screen.
2) MATIC still uses ETH's icon
3) After DAO is successfully created, apps not loading, and have unknown name/logo on permission/apps center...