### PR TITLE
DAO not found modal improvement DAO-268

### DIFF
--- a/src/components/Error/DAONotFoundError.js
+++ b/src/components/Error/DAONotFoundError.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { useTheme, textStyle, Link, GU, Info } from '@aragon/ui'
+import styled from 'styled-components'
+
 import { isAddress } from '../../util/web3'
 import { useWallet } from '../../contexts/wallet'
 import { getNetworkFullName } from '../../util/network'
@@ -11,6 +13,7 @@ DAONotFoundError.propTypes = {
 
 function DAONotFoundError({ dao }) {
   const theme = useTheme()
+  const alternativeNetworks = ['polygon', 'ropsten']
 
   return (
     <React.Fragment>
@@ -24,7 +27,16 @@ function DAONotFoundError({ dao }) {
       >
         Organization not found
       </h1>
-      <NotFoundAtAllMessage dao={dao} />
+      <MessageContainer>
+        {alternativeNetworks.length ? (
+          <NotFoundOnNetworkMessage
+            dao={dao}
+            alternatives={alternativeNetworks}
+          />
+        ) : (
+          <NotFoundAtAllMessage dao={dao} />
+        )}
+      </MessageContainer>
       <Info>
         If you arrived here through a link, please double check that you were
         given the correct link. Alternatively, you may{' '}
@@ -49,25 +61,65 @@ function NotFoundAtAllMessage({ dao }) {
   const { networkType } = useWallet()
 
   return (
-    <div
-      css={`
-        margin-bottom: ${6 * GU}px;
-        text-align: center;
-        color: ${theme.surfaceContentSecondary};
-        ${textStyle('body2')};
-      `}
-    >
+    <Message color={theme.surfaceContentSecondary}>
       There’s no organization associated with{' '}
       {isAddress(dao) ? (
-        <span css="font-weight: bold;">“{dao}”</span>
+        <span css="font-weight: bold;">'{dao}'</span>
       ) : (
-        <React.Fragment>
-          <strong>“{dao}”</strong>
-        </React.Fragment>
+        <span css="font-weight: bold;">'{dao}'</span>
       )}{' '}
       on the {getNetworkFullName(networkType)}.
-    </div>
+    </Message>
   )
 }
+
+NotFoundOnNetworkMessage.propTypes = {
+  dao: PropTypes.string,
+  alternatives: PropTypes.string,
+}
+
+function NotFoundOnNetworkMessage({ dao, alternatives }) {
+  const theme = useTheme()
+  const { networkType } = useWallet()
+
+  return (
+    <React.Fragment>
+      <Message color={theme.surfaceContentSecondary}>
+        There’s no organization associated with{' '}
+        {isAddress(dao) ? (
+          <span css="font-weight: bold;">'{dao}'</span>
+        ) : (
+          <span css="font-weight: bold;">'{dao}'</span>
+        )}{' '}
+        on the {getNetworkFullName(networkType)}, but it does exist on another
+        chain. You may switch the application to another chain to see it.
+      </Message>
+      <LinksList>
+        {alternatives.map(a => (
+          <li>
+            <Link>
+              Open {dao} on {a}
+            </Link>
+          </li>
+        ))}
+      </LinksList>
+    </React.Fragment>
+  )
+}
+
+const MessageContainer = styled.div`
+  margin-bottom: ${6 * GU}px;
+  text-align: center;
+`
+
+const Message = styled.p`
+  ${textStyle('body2')};
+  color: ${props => props.color};
+`
+
+const LinksList = styled.ul`
+  list-style: none;
+  padding-top: ${2 * GU}px;
+`
 
 export default DAONotFoundError

--- a/src/components/Error/DAONotFoundError.js
+++ b/src/components/Error/DAONotFoundError.js
@@ -13,6 +13,7 @@ DAONotFoundError.propTypes = {
 
 function DAONotFoundError({ dao }) {
   const theme = useTheme()
+  // mock object, to be determined dynamically as specified in DAO-269
   const alternativeNetworks = ['polygon', 'ropsten']
 
   return (
@@ -62,12 +63,8 @@ function NotFoundAtAllMessage({ dao }) {
 
   return (
     <Message color={theme.surfaceContentSecondary}>
-      There’s no organization associated with{' '}
-      {isAddress(dao) ? (
-        <span css="font-weight: bold;">'{dao}'</span>
-      ) : (
-        <span css="font-weight: bold;">'{dao}'</span>
-      )}{' '}
+      There’s no organization associated with
+      <span css="font-weight: bold;">'{dao}'</span>
       on the {getNetworkFullName(networkType)}.
     </Message>
   )
@@ -85,20 +82,16 @@ function NotFoundOnNetworkMessage({ dao, alternatives }) {
   return (
     <React.Fragment>
       <Message color={theme.surfaceContentSecondary}>
-        There’s no organization associated with{' '}
-        {isAddress(dao) ? (
-          <span css="font-weight: bold;">'{dao}'</span>
-        ) : (
-          <span css="font-weight: bold;">'{dao}'</span>
-        )}{' '}
-        on the {getNetworkFullName(networkType)}, but it does exist on another
-        chain. You may switch the application to another chain to see it.
+        There’s no organization associated with
+        <span css="font-weight: bold;">'{dao}'</span> on the
+        {getNetworkFullName(networkType)}, but it does exist on another chain.
+        You may switch the application to another chain to see it.
       </Message>
       <LinksList>
         {alternatives.map(a => (
           <li>
             <Link>
-              Open {dao} on {a}
+              Open {!isAddress(dao) ? dao : 'it'} on {a}
             </Link>
           </li>
         ))}

--- a/src/components/Error/DAONotFoundError.js
+++ b/src/components/Error/DAONotFoundError.js
@@ -29,15 +29,15 @@ function DAONotFoundError({ dao }) {
           ${textStyle('body2')};
         `}
       >
-        It looks like there’s no organization associated with{' '}
+        There’s no organization associated with{' '}
         {isAddress(dao) ? (
           <span css="font-weight: bold;">“{dao}”</span>
         ) : (
           <React.Fragment>
-            the <strong>“{dao}”</strong> ENS domain
+            <strong>“{dao}”</strong>
           </React.Fragment>
         )}{' '}
-        on the Ethereum {getNetworkFullName(networkType)}.
+        on the {getNetworkFullName(networkType)}.
       </div>
       <Info>
         If you arrived here through a link, please double check that you were

--- a/src/components/Error/DAONotFoundError.js
+++ b/src/components/Error/DAONotFoundError.js
@@ -5,9 +5,12 @@ import { isAddress } from '../../util/web3'
 import { useWallet } from '../../contexts/wallet'
 import { getNetworkFullName } from '../../util/network'
 
+DAONotFoundError.propTypes = {
+  dao: PropTypes.string,
+}
+
 function DAONotFoundError({ dao }) {
   const theme = useTheme()
-  const { networkType } = useWallet()
 
   return (
     <React.Fragment>
@@ -21,24 +24,7 @@ function DAONotFoundError({ dao }) {
       >
         Organization not found
       </h1>
-      <div
-        css={`
-          margin-bottom: ${6 * GU}px;
-          text-align: center;
-          color: ${theme.surfaceContentSecondary};
-          ${textStyle('body2')};
-        `}
-      >
-        There’s no organization associated with{' '}
-        {isAddress(dao) ? (
-          <span css="font-weight: bold;">“{dao}”</span>
-        ) : (
-          <React.Fragment>
-            <strong>“{dao}”</strong>
-          </React.Fragment>
-        )}{' '}
-        on the {getNetworkFullName(networkType)}.
-      </div>
+      <NotFoundAtAllMessage dao={dao} />
       <Info>
         If you arrived here through a link, please double check that you were
         given the correct link. Alternatively, you may{' '}
@@ -54,8 +40,34 @@ function DAONotFoundError({ dao }) {
   )
 }
 
-DAONotFoundError.propTypes = {
+NotFoundAtAllMessage.propTypes = {
   dao: PropTypes.string,
+}
+
+function NotFoundAtAllMessage({ dao }) {
+  const theme = useTheme()
+  const { networkType } = useWallet()
+
+  return (
+    <div
+      css={`
+        margin-bottom: ${6 * GU}px;
+        text-align: center;
+        color: ${theme.surfaceContentSecondary};
+        ${textStyle('body2')};
+      `}
+    >
+      There’s no organization associated with{' '}
+      {isAddress(dao) ? (
+        <span css="font-weight: bold;">“{dao}”</span>
+      ) : (
+        <React.Fragment>
+          <strong>“{dao}”</strong>
+        </React.Fragment>
+      )}{' '}
+      on the {getNetworkFullName(networkType)}.
+    </div>
+  )
 }
 
 export default DAONotFoundError

--- a/src/network-config.js
+++ b/src/network-config.js
@@ -23,7 +23,7 @@ export const networkConfigs = {
       'https://api.thegraph.com/subgraphs/name/aragon/aragon-mainnet',
     settings: {
       chainId: 1,
-      networkType: 'main',
+      testnet: false,
       ...KNOWN_CHAINS.get(1),
       live: true,
     },
@@ -43,7 +43,7 @@ export const networkConfigs = {
       'https://api.thegraph.com/subgraphs/name/aragon/aragon-rinkeby',
     settings: {
       chainId: 4,
-      networkType: 'test',
+      testnet: true,
       ...KNOWN_CHAINS.get(4), // as returned by web3.eth.net.getNetworkType()
       live: true,
     },
@@ -61,7 +61,7 @@ export const networkConfigs = {
     connectGraphEndpoint: null,
     settings: {
       chainId: 3,
-      networkType: 'test',
+      testnet: true,
       ...KNOWN_CHAINS.get(3),
       live: true,
     },
@@ -81,7 +81,7 @@ export const networkConfigs = {
       // a chainId of value 1337, but for the sake of configuration
       // we expose a way to change this value.
       chainId: 1337,
-      networkType: 'test',
+      testnet: true,
 
       ...KNOWN_CHAINS.get(1337),
       live: false,
@@ -102,7 +102,7 @@ export const networkConfigs = {
     connectGraphEndpoint: null,
     settings: {
       chainId: 100,
-      networkType: 'main',
+      testnet: false,
       ...KNOWN_CHAINS.get(100),
       live: true,
     },
@@ -121,7 +121,7 @@ export const networkConfigs = {
     connectGraphEndpoint: null,
     settings: {
       chainId: 137,
-      networkType: 'main',
+      testnet: false,
       ...KNOWN_CHAINS.get(137),
       live: true,
     },
@@ -139,7 +139,7 @@ export const networkConfigs = {
     connectGraphEndpoint: null,
     settings: {
       chainId: 80001,
-      networkType: 'test',
+      testnet: true,
       ...KNOWN_CHAINS.get(80001),
       live: true,
     },

--- a/src/util/network.js
+++ b/src/util/network.js
@@ -6,11 +6,11 @@ export function isOnEthMainnet(networkType) {
 }
 
 export function isMainnet(networkType) {
-  return getNetworkConfig(networkType).settings?.networkType === 'main'
+  return !getNetworkConfig(networkType).settings?.testnet
 }
 
 export function isTestnet(networkType) {
-  return getNetworkConfig(networkType).settings?.networkType === 'test'
+  return !getNetworkConfig(networkType).settings?.testnet
 }
 
 export function getDaiTokenAddress(networkType) {


### PR DESCRIPTION
This PR improves the error-modal shown when a user navigates to a DAO that does not exist on the current network. Currently, the modal only informs the user that a DAO does not exist. With this PR the user is additionally informed of DAOs with the same address/ENS name on other networks, if they exist.

This PR only introduces visual changes, the logic is to be implemented in a future PR.