### PR TITLE
Feautre/search daos dao 269

### DIFF
--- a/src/components/Error/DAONotFoundError.js
+++ b/src/components/Error/DAONotFoundError.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { useTheme, textStyle, Link, GU, Info } from '@aragon/ui'
 import styled from 'styled-components'
@@ -7,6 +7,7 @@ import { isAddress } from '../../util/web3'
 import { useWallet } from '../../contexts/wallet'
 import { getNetworkFullName } from '../../util/network'
 import { useDetectDao } from '../../hooks/useDetectDao'
+import { useRouting } from '../../routing'
 
 DAONotFoundError.propTypes = {
   dao: PropTypes.string,
@@ -69,7 +70,19 @@ NotFoundOnNetworkMessage.propTypes = {
 
 function NotFoundOnNetworkMessage({ dao, alternatives }) {
   const theme = useTheme()
-  const { networkType } = useWallet()
+  const routing = useRouting()
+  const { networkType, changeNetworkTypeDisconnected } = useWallet()
+
+  const goToOrg = useCallback(
+    (orgAddress, networType) => {
+      changeNetworkTypeDisconnected(networType)
+      routing.update(locator => ({
+        ...locator,
+        mode: { name: 'org', orgAddress },
+      }))
+    },
+    [routing]
+  )
 
   return (
     <React.Fragment>
@@ -82,7 +95,7 @@ function NotFoundOnNetworkMessage({ dao, alternatives }) {
       <LinksList>
         {alternatives.map(a => (
           <li key={a}>
-            <Link>
+            <Link onClick={() => goToOrg(dao, a)}>
               Open {!isAddress(dao) ? dao : 'it'} on {a}
             </Link>
           </li>

--- a/src/components/Error/DAONotFoundError.js
+++ b/src/components/Error/DAONotFoundError.js
@@ -64,7 +64,7 @@ function NotFoundAtAllMessage({ dao }) {
 
 NotFoundOnNetworkMessage.propTypes = {
   dao: PropTypes.string,
-  alternatives: PropTypes.string,
+  alternatives: PropTypes.arrayOf(PropTypes.string),
 }
 
 function NotFoundOnNetworkMessage({ dao, alternatives }) {
@@ -81,7 +81,7 @@ function NotFoundOnNetworkMessage({ dao, alternatives }) {
       </Message>
       <LinksList>
         {alternatives.map(a => (
-          <li>
+          <li key={a}>
             <Link>
               Open {!isAddress(dao) ? dao : 'it'} on {a}
             </Link>

--- a/src/components/Error/DAONotFoundError.js
+++ b/src/components/Error/DAONotFoundError.js
@@ -81,7 +81,7 @@ function NotFoundOnNetworkMessage({ dao, alternatives }) {
         mode: { name: 'org', orgAddress },
       }))
     },
-    [routing]
+    [routing, changeNetworkTypeDisconnected]
   )
 
   return (

--- a/src/components/Error/DAONotFoundError.js
+++ b/src/components/Error/DAONotFoundError.js
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import { isAddress } from '../../util/web3'
 import { useWallet } from '../../contexts/wallet'
 import { getNetworkFullName } from '../../util/network'
+import { useDetectDao } from '../../hooks/useDetectDao'
 
 DAONotFoundError.propTypes = {
   dao: PropTypes.string,
@@ -13,27 +14,18 @@ DAONotFoundError.propTypes = {
 
 function DAONotFoundError({ dao }) {
   const theme = useTheme()
-  // mock object, to be determined dynamically as specified in DAO-269
-  const alternativeNetworks = ['polygon', 'ropsten']
+  const { loading, networks } = useDetectDao(dao)
 
   return (
     <React.Fragment>
-      <h1
-        css={`
-          color: ${theme.surfaceContent};
-          ${textStyle('title2')};
-          margin-bottom: ${1.5 * GU}px;
-          text-align: center;
-        `}
-      >
+      <ModalTitle color={theme.surfaceContent}>
         Organization not found
-      </h1>
+      </ModalTitle>
       <MessageContainer>
-        {alternativeNetworks.length ? (
-          <NotFoundOnNetworkMessage
-            dao={dao}
-            alternatives={alternativeNetworks}
-          />
+        {loading ? (
+          <div />
+        ) : networks?.length ? (
+          <NotFoundOnNetworkMessage dao={dao} alternatives={networks} />
         ) : (
           <NotFoundAtAllMessage dao={dao} />
         )}
@@ -99,6 +91,13 @@ function NotFoundOnNetworkMessage({ dao, alternatives }) {
     </React.Fragment>
   )
 }
+
+const ModalTitle = styled.h1`
+  color: ${props => props.color};
+  ${textStyle('title2')};
+  margin-bottom: ${1.5 * GU}px;
+  text-align: center;
+`
 
 const MessageContainer = styled.div`
   margin-bottom: ${6 * GU}px;

--- a/src/components/Modals/NetworkSwitchModal/NetworkSwitchModal.js
+++ b/src/components/Modals/NetworkSwitchModal/NetworkSwitchModal.js
@@ -64,6 +64,7 @@ function ButtonsRow({ networkNames, onClose }) {
     <Row>
       {networkNames.map(n => (
         <FixWidthButton
+          key={n}
           onClick={() => {
             changeNetworkTypeDisconnected(n)
             onClose()

--- a/src/hooks/useDetectDao.js
+++ b/src/hooks/useDetectDao.js
@@ -12,47 +12,44 @@ import { completeDomain } from '../check-domain'
  * the domain was found
  */
 export function useDetectDao(domain) {
-  const [networks, setNetowrks] = useState([])
+  const [networks, setNetworks] = useState([])
   const [loading, setLoading] = useState(true)
   const { web3 } = useClientWeb3()
 
   useEffect(() => {
-    setNetowrks(false)
     setLoading(true)
 
     let cancelled = false
 
     const check = async () => {
       // TODO define active networks as field in network-config
-      const networksToCheck = ['main', 'matic', 'rinkeby', 'mumbai']
+      console.log(domain)
+      const networksToCheck = ['main']
       const awalabilityPromise = networksToCheck.map(n =>
         isEnsDomainAvailable(n, web3, completeDomain(domain))
       )
 
       try {
         const availableNetworks = await Promise.all(awalabilityPromise)
-        networksToCheck.filter((_, i) => availableNetworks[i])
+        const filteredNetworks = networksToCheck.filter(
+          (_, i) => availableNetworks[i]
+        )
+
         if (!cancelled) {
           setLoading(false)
-          setNetowrks(availableNetworks)
+          setNetworks(filteredNetworks)
         }
       } catch (err) {
-        // retry every second
-        setTimeout(check, 1000)
+        console.error(err)
       }
     }
 
-    // Only start checking after 300ms
-    setTimeout(() => {
-      if (!cancelled) {
-        check(networks)
-      }
-    }, 300)
-
+    check()
     return () => {
+      console.log('GOT CANCELED')
       cancelled = true
     }
-  }, [domain, web3, networks])
+  }, [domain, web3])
 
   const data = useMemo(() => {
     return { loading, networks }

--- a/src/hooks/useDetectDao.js
+++ b/src/hooks/useDetectDao.js
@@ -22,7 +22,8 @@ export function useDetectDao(domain) {
 
     const checkWithProvider = async () => {
       // TODO define active networks as field in network-config
-      const networksToCheck = ['main', 'rinkeby']
+      // NOTE matic fails for some reason [VR 22-09-2021]
+      const networksToCheck = ['main', 'rinkeby', 'mumbai', 'matic']
       try {
         const providers = networksToCheck.map(n => ({
           network: n,

--- a/src/hooks/useDetectDao.js
+++ b/src/hooks/useDetectDao.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import { isEnsDomainAvailable } from '../aragonjs-wrapper'
 import { completeDomain } from '../check-domain'
+import { getActiveNetworks } from '../util/network'
 import { getWeb3Provider } from '../util/web3'
 
 /**
@@ -21,9 +22,8 @@ export function useDetectDao(domain) {
     let cancelled = false
 
     const checkWithProvider = async () => {
-      // TODO define active networks as field in network-config
-      // NOTE matic fails for some reason [VR 22-09-2021]
-      const networksToCheck = ['main', 'rinkeby', 'mumbai', 'matic']
+      // TODO looku-up on matic fails for some reason. [VR 22-09-2021]
+      const networksToCheck = getActiveNetworks().filter(n => n !== 'matic')
       try {
         const providers = networksToCheck.map(n => ({
           network: n,

--- a/src/hooks/useDetectDao.js
+++ b/src/hooks/useDetectDao.js
@@ -1,0 +1,1 @@
+// TODO implement useDetectDao react hook

--- a/src/hooks/useDetectDao.js
+++ b/src/hooks/useDetectDao.js
@@ -1,1 +1,62 @@
-// TODO implement useDetectDao react hook
+import { useState, useEffect, useMemo } from 'react'
+import { isEnsDomainAvailable } from '../aragonjs-wrapper'
+import { useClientWeb3 } from '../contexts/ClientWeb3Context'
+import { completeDomain } from '../check-domain'
+
+/**
+ * This hook checks a list of networks for an ens domain. It returns all
+ * network names on which the domain is found.
+ *
+ * @param {string} domain domain to check
+ * @returns {{loading, networks}} object containing a loading state and a list of networks on which
+ * the domain was found
+ */
+export function useDetectDao(domain) {
+  const [networks, setNetowrks] = useState([])
+  const [loading, setLoading] = useState(true)
+  const { web3 } = useClientWeb3()
+
+  useEffect(() => {
+    setNetowrks(false)
+    setLoading(true)
+
+    let cancelled = false
+
+    const check = async () => {
+      // TODO define active networks as field in network-config
+      const networksToCheck = ['main', 'matic', 'rinkeby', 'mumbai']
+      const awalabilityPromise = networksToCheck.map(n =>
+        isEnsDomainAvailable(n, web3, completeDomain(domain))
+      )
+
+      try {
+        const availableNetworks = await Promise.all(awalabilityPromise)
+        networksToCheck.filter((_, i) => availableNetworks[i])
+        if (!cancelled) {
+          setLoading(false)
+          setNetowrks(availableNetworks)
+        }
+      } catch (err) {
+        // retry every second
+        setTimeout(check, 1000)
+      }
+    }
+
+    // Only start checking after 300ms
+    setTimeout(() => {
+      if (!cancelled) {
+        check(networks)
+      }
+    }, 300)
+
+    return () => {
+      cancelled = true
+    }
+  }, [domain, web3, networks])
+
+  const data = useMemo(() => {
+    return { loading, networks }
+  }, [networks, loading])
+
+  return data
+}

--- a/src/network-config.js
+++ b/src/network-config.js
@@ -9,6 +9,7 @@ const DAI_RINKEBY_TOKEN_ADDRESS = '0x0527e400502d0cb4f214dd0d2f2a323fc88ff924'
 // cconnectGraphEndpoint is https://github.com/aragon/connect/tree/master/packages/connect-thegraph
 export const networkConfigs = {
   [KNOWN_CHAINS.get(1).type]: {
+    isActive: true,
     enableMigrateBanner: true,
     addresses: {
       ensRegistry:
@@ -29,6 +30,7 @@ export const networkConfigs = {
     },
   },
   [KNOWN_CHAINS.get(4).type]: {
+    isActive: true,
     enableMigrateBanner: true,
     addresses: {
       ensRegistry:
@@ -49,6 +51,7 @@ export const networkConfigs = {
     },
   },
   [KNOWN_CHAINS.get(3).type]: {
+    isActive: false,
     enableMigrateBanner: true,
     addresses: {
       ensRegistry:
@@ -68,6 +71,7 @@ export const networkConfigs = {
   },
   [KNOWN_CHAINS.get(1337).type]: {
     enableMigrateBanner: true,
+    isActive: false,
     addresses: {
       ensRegistry: localEnsRegistryAddress,
       governExecutorProxy: null,
@@ -91,6 +95,7 @@ export const networkConfigs = {
   // and expected that a few things will break.
   [KNOWN_CHAINS.get(100).type]: {
     enableMigrateBanner: false,
+    isActive: false,
     addresses: {
       ensRegistry:
         localEnsRegistryAddress || '0xaafca6b0c89521752e559650206d7c925fd0e530',
@@ -109,6 +114,7 @@ export const networkConfigs = {
   },
   [KNOWN_CHAINS.get(137).type]: {
     enableMigrateBanner: false,
+    isActive: true,
     addresses: {
       ensRegistry:
         localEnsRegistryAddress || '0x3c70a0190d09f34519e6e218364451add21b7d4b',
@@ -129,6 +135,7 @@ export const networkConfigs = {
   },
   [KNOWN_CHAINS.get(80001).type]: {
     enableMigrateBanner: false,
+    isActive: true,
     addresses: {
       ensRegistry:
         localEnsRegistryAddress || '0x431f0eed904590b176f9ff8c36a1c4ff0ee9b982',
@@ -148,6 +155,7 @@ export const networkConfigs = {
   },
   unknown: {
     enableMigrateBanner: false,
+    isActive: false,
     addresses: {
       ensRegistry: localEnsRegistryAddress,
       governExecutorProxy: null,

--- a/src/onboarding/Welcome/OpenOrg.js
+++ b/src/onboarding/Welcome/OpenOrg.js
@@ -10,6 +10,7 @@ import {
   useKeyDown,
   useTheme,
 } from '@aragon/ui'
+import styled from 'styled-components'
 import KEYS from '../../keycodes'
 import DomainField from '../../components/DomainField/DomainField'
 import { useCheckDomain, DOMAIN_CHECK, DOMAIN_ERROR } from '../../check-domain'

--- a/src/onboarding/Welcome/OpenOrg.js
+++ b/src/onboarding/Welcome/OpenOrg.js
@@ -45,36 +45,12 @@ function OpenOrg({ onOpenOrg, onBack }) {
 
   return (
     <Box padding={5 * GU}>
-      <Bar
-        css={`
-          margin: -${5 * GU}px -${5 * GU}px 0;
-          border: 0;
-          border-bottom: 1px solid ${theme.border};
-          border-bottom-left-radius: 0;
-          border-bottom-right-radius: 0;
-        `}
-      >
+      <BackButtonContainer borderColor={theme.border}>
         <BackButton onClick={onBack} />
-      </Bar>
+      </BackButtonContainer>
 
-      <form
-        onSubmit={handleSubmit}
-        css={`
-          display: flex;
-          flex-direction: column;
-          width: 100%;
-          height: ${36 * GU}px;
-        `}
-      >
-        <div
-          css={`
-            flex-grow: 1;
-            display: flex;
-            flex-direction: column;
-            width: 100%;
-            justify-content: center;
-          `}
-        >
+      <Form onSubmit={handleSubmit}>
+        <InputFieldContainer>
           <div css="position: relative">
             <DomainField
               ref={handleDomainFieldRef}
@@ -97,20 +73,15 @@ function OpenOrg({ onOpenOrg, onBack }) {
               </Info>
             )}
           </div>
-        </div>
-        <div
-          css={`
-            display: flex;
-            justify-content: flex-end;
-          `}
-        >
+        </InputFieldContainer>
+        <SubmitButtonContainer>
           <Button
             label="Open organization"
             mode="strong"
             onClick={handleSubmit}
           />
-        </div>
-      </form>
+        </SubmitButtonContainer>
+      </Form>
     </Box>
   )
 }
@@ -120,4 +91,31 @@ OpenOrg.propTypes = {
   onOpenOrg: PropTypes.func.isRequired,
 }
 
+const BackButtonContainer = styled(Bar)`
+  margin: -${5 * GU}px -${5 * GU}px 0;
+  border: 0;
+  border-bottom: 1px solid ${props => props.borderColor};
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+`
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: ${36 * GU}px;
+`
+
+const InputFieldContainer = styled.div`
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  justify-content: center;
+`
+
+const SubmitButtonContainer = styled.div`
+  display: flex;
+  flex-content: flex-end;
+`
 export default OpenOrg

--- a/src/util/network.js
+++ b/src/util/network.js
@@ -1,5 +1,15 @@
 import { KNOWN_CHAINS } from 'use-wallet'
-import { getNetworkConfig } from '../network-config'
+import { getNetworkConfig, networkConfigs } from '../network-config'
+
+export const isActiveNetwork = networkType => {
+  return getNetworkConfig(networkType).isActive
+}
+
+export const getActiveNetworks = () => {
+  return Object.values(networkConfigs)
+    .filter(v => v.isActive)
+    .map(n => n.settings.type)
+}
 
 export function isOnEthMainnet(networkType) {
   return networkType === KNOWN_CHAINS.get(1).type


### PR DESCRIPTION
This PR adds the actual functionality to the `DaoNotFoundModal`. In particular:

- The list of alternative networks on which a dao is found is now dynamic. (I.e., the domain entered in the url is searched on all networks if not found on the current. If the domain is found on any other network, that network is displayed as a link)
- Clicking the link now changes the network and takes the user to the dao page. 