### PR TITLE
Fix: Hide network indicator DAO-270

### DIFF
--- a/src/components/NetworkIndicator/NetworkIndicator.js
+++ b/src/components/NetworkIndicator/NetworkIndicator.js
@@ -11,8 +11,12 @@ NetworkIndicator.propTypes = {
 }
 // TODO try adding Modal from here
 export function NetworkIndicator({ clickHandler }) {
-  const { networkType } = useWallet()
+  const { networkType, status } = useWallet()
   const networkName = getNetworkShortName(networkType)
+
+  if (status === 'connected') {
+    return null
+  }
 
   return (
     <DisplacedDiv>


### PR DESCRIPTION
This PR hide the network indicator label next to the wallet connector module, when a wallet is connected.