### PR TITLE
Adds calculation for priorityFee

### DIFF
--- a/src/components/SignerPanel/SignerPanel.js
+++ b/src/components/SignerPanel/SignerPanel.js
@@ -335,8 +335,7 @@ class SignerPanel extends React.PureComponent {
       return {
         ...transaction,
         maxPriorityFeePerGas: Math.round(
-          feeHistories.reduce((acc, fee) => acc + fee, 0) /
-            feeHistories.length
+          feeHistories.reduce((acc, fee) => acc + fee, 0) / feeHistories.length
         ),
       }
     }

--- a/src/onboarding/Create/Create.js
+++ b/src/onboarding/Create/Create.js
@@ -511,26 +511,32 @@ const Create = React.memo(function Create({
     [web3]
   )
 
-  const applyEstimatePriorityFee = useCallback(async transaction => {
-    const priorityFeeHistory = await web3.eth.getFeeHistory('4', 'latest', [10])
-    if (
-      priorityFeeHistory &&
-      priorityFeeHistory.reward &&
-      priorityFeeHistory.reward.length > 0
-    ) {
-      // takes the top 10 of the last 4 blocks and take the average after removing zero values
-      const feeHistories = priorityFeeHistory.reward
-        .map(fee => walletWeb3.utils.hexToNumber(fee[0]))
-        .filter(fee => fee > 0)
-      return {
-        ...transaction,
-        maxPriorityFeePerGas: Math.round(
-          feeHistories.reduce((acc, fee) => acc + fee, 0) / feeHistories.length
-        ),
+  const applyEstimatePriorityFee = useCallback(
+    async transaction => {
+      const priorityFeeHistory = await web3.eth.getFeeHistory('4', 'latest', [
+        10,
+      ])
+      if (
+        priorityFeeHistory &&
+        priorityFeeHistory.reward &&
+        priorityFeeHistory.reward.length > 0
+      ) {
+        // takes the top 10 of the last 4 blocks and take the average after removing zero values
+        const feeHistories = priorityFeeHistory.reward
+          .map(fee => web3.utils.hexToNumber(fee[0]))
+          .filter(fee => fee > 0)
+        return {
+          ...transaction,
+          maxPriorityFeePerGas: Math.round(
+            feeHistories.reduce((acc, fee) => acc + fee, 0) /
+              feeHistories.length
+          ),
+        }
       }
-    }
-    return transaction
-  })
+      return transaction
+    },
+    [web3]
+  )
 
   const [attempts, setAttempts] = useState(0)
 


### PR DESCRIPTION
With the London fork priority fees are introduced. Web3.js doesn't calculate them according to the network but rather uses a fixed amount of 2.5 gwei.
This pull introduces a calculation for the priority fee based on the `eth_feeHistory` RPC call.