### PR TITLE
 Need to increase priorityFees on Polygon

### DIFF
--- a/src/components/SignerPanel/SignerPanel.js
+++ b/src/components/SignerPanel/SignerPanel.js
@@ -25,6 +25,9 @@ import {
   isSignatureSuccess,
 } from './signer-statuses'
 
+const { chainId } = useWallet()
+const PRIORITY_FEE_MULTIPLIER = chainId===137 ? 1.3 : 1  // need more agressive priorityFees on Polygon
+
 const INITIAL_STATE = {
   actionPaths: [],
   directPath: false,
@@ -321,7 +324,7 @@ class SignerPanel extends React.PureComponent {
     const estimatedPriorityFee = await getPriorityFeeEstimation(walletWeb3)
     return {
       ...transaction,
-      maxPriorityFeePerGas: estimatedPriorityFee,
+      maxPriorityFeePerGas: estimatedPriorityFee * PRIORITY_FEE_MULTIPLIER,
     }
   }
 


### PR DESCRIPTION
Need more agressive priorityFees since april-23 otherwise transactions on Polygon got stuck (in MATIC it is about +0.01 to ~0.05 overall fee). You can reproduce that issue by signing any tx on Polygon DAO by Client. And comparing to manually set 'agressive' gas fee in Metamask (the last one will work).